### PR TITLE
feat(proxy): add HTTPS Nginx reverse proxy (Docker + SSL script)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PORT=3000
+NODE_ENV=production
+CORS_ORIGIN=http://<EC2_PUBLIC_IP>
+MONGO_URI=mongodb://mongo:27017/appdb?authSource=admin
+MONGO_DB=appdb

--- a/infra/k8s/proxy-configmap.yml
+++ b/infra/k8s/proxy-configmap.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+data:
+  nginx.conf: |
+    events {}
+    http {
+      upstream frontend { server frontend-service:80; }
+      upstream backend  { server backend-service:3000; }
+      upstream mongo_ui { server mongo-express-service:8081; }
+
+      server {
+        listen 443 ssl;
+        ssl_certificate     /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+        location /     { proxy_pass http://frontend; }
+        location /api/ { proxy_pass http://backend; }
+        location /db/  { proxy_pass http://mongo_ui; }
+      }
+    }

--- a/infra/k8s/proxy-deployment.yml
+++ b/infra/k8s/proxy-deployment.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy
+  template:
+    metadata:
+      labels:
+        app: proxy
+    spec:
+      containers:
+      - name: proxy
+        image: nginx:latest
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: certs
+          mountPath: /etc/nginx/certs
+      volumes:
+      - name: config
+        configMap:
+          name: proxy-config
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+      - name: certs
+        secret:
+          secretName: tls-dev

--- a/infra/k8s/proxy-service.yml
+++ b/infra/k8s/proxy-service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-service
+spec:
+  type: NodePort
+  selector:
+    app: proxy
+  ports:
+    - port: 443
+      targetPort: 443
+      nodePort: 30443

--- a/infra/nginx-proxy/compose.nginx.yml
+++ b/infra/nginx-proxy/compose.nginx.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  proxy:
+    image: nginx:latest
+    container_name: proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./infra/nginx-proxy/certs:/etc/nginx/certs:ro
+    depends_on:
+      - frontend
+      - backend
+      - mongo-express

--- a/infra/nginx-proxy/generate_ssl.sh
+++ b/infra/nginx-proxy/generate_ssl.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir -p $(dirname $0)/certs
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout $(dirname $0)/certs/localhost.key \
+  -out $(dirname $0)/certs/localhost.crt \
+  -subj "/CN=localhost"

--- a/infra/nginx-proxy/nginx.conf
+++ b/infra/nginx-proxy/nginx.conf
@@ -1,0 +1,22 @@
+events {}
+http {
+    upstream frontend { server frontend:80; }
+    upstream backend { server backend:3000; }
+    upstream mongo_ui { server mongo-express:8081; }
+
+    server {
+        listen 80;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+
+        location / { proxy_pass http://frontend; }
+        location /api/ { proxy_pass http://backend; }
+        location /db/ { proxy_pass http://mongo_ui; }
+    }
+}
+


### PR DESCRIPTION
### Summary
This PR introduces an HTTPS-enabled Nginx reverse proxy for the MERN app.

### Changes
- Added `nginx.conf` for reverse proxy configuration
- Added `compose.nginx.yml` override for Docker Compose integration
- Added `generate_ssl.sh` script for generating self-signed TLS certificates
- Created folder structure for Kubernetes manifests (`infra/k8s/`)

### How to Test
1. Run `./infra/nginx-proxy/generate_ssl.sh` to generate certs
2. Start containers with:
   docker compose -f docker-compose.yml -f infra/nginx-proxy/compose.nginx.yml up -d --build
3. Access:
   - `https://<EC2-IP>/` → frontend
   - `https://<EC2-IP>/api/` → backend
   - `https://<EC2-IP>/db/` → mongo-express UI

### Next Steps
- Apply Kubernetes manifests (`proxy-configmap.yml`, `proxy-deployment.yml`, `proxy-service.yml`) to test proxy in cluster
